### PR TITLE
Fix window spacing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>crosshair</artifactId>
 	<url>https://github.com/K-Meech/crosshair</url>
-	<version>1.0.4</version>
+	<version>1.0.5</version>
 	<name>Crosshair</name>
 	<description>Assisted 3D targeting via an ultramicrotome</description>
 	<inceptionYear>2020</inceptionYear>

--- a/src/main/java/de/embl/schwab/crosshair/Crosshair.java
+++ b/src/main/java/de/embl/schwab/crosshair/Crosshair.java
@@ -122,7 +122,7 @@ public class Crosshair {
 
 		CrosshairFrame crosshairFrame = new CrosshairFrame(this);
 
-		spaceOutWindows( bdvHandle, crosshairFrame, universe );
+		spaceOutWindows( crosshairFrame, bdvHandle, universe );
 	}
 
 	public BdvHandle getBdvHandle() {

--- a/src/main/java/de/embl/schwab/crosshair/targetingaccuracy/TargetingAccuracy.java
+++ b/src/main/java/de/embl/schwab/crosshair/targetingaccuracy/TargetingAccuracy.java
@@ -105,7 +105,7 @@ public class TargetingAccuracy {
             reader.loadSettings( settings, planeManager,
                     accuracyFrame.getImagesPanel().getImageNameToContent(), accuracyFrame.getOtherPanel() );
 
-            spaceOutWindows(beforeStackSource.getBdvHandle(), accuracyFrame, universe);
+            spaceOutWindows(accuracyFrame, beforeStackSource.getBdvHandle(), universe);
 
         }
     }

--- a/src/main/java/de/embl/schwab/crosshair/utils/Utils.java
+++ b/src/main/java/de/embl/schwab/crosshair/utils/Utils.java
@@ -40,16 +40,38 @@ public class Utils {
 
     }
 
-    public static void spaceOutWindows( BdvHandle bdvHandle, JFrame frame, Image3DUniverse universe ) {
-        // Space out windows like here:
-        // https://github.com/mobie/mobie-viewer-fiji/blob/9f7367902cc0bd01e089f7ce40cdcf0ee0325f1e/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesPanel.java#L369
+    /**
+     * Space out the three Crosshair windows, with the JFrame on the left (with controls), big data viewer in the
+     * middle and the 3D viewer on the right.
+     * Based on
+     * https://github.com/mobie/mobie-viewer-fiji/blob/main/src/main/java/org/embl/mobie/ui/WindowArrangementHelper.java
+     * @param frame JFrame containing controls
+     * @param bdvHandle bdvHandle of the BigDataViewer window
+     * @param universe universe of the 3D viewer
+     */
+    public static void spaceOutWindows( JFrame frame, BdvHandle bdvHandle, Image3DUniverse universe ) {
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
         Window viewFrame = SwingUtilities.getWindowAncestor(bdvHandle.getViewerPanel());
+
+        // Make sure bigdataviewer + 3D viewer aren't taller than the screen
+        int viewHeight = viewFrame.getHeight();
+        if (viewHeight > screenSize.getHeight()) {
+            viewHeight = (int) Math.floor(screenSize.getHeight());
+        }
+
+        // Place the 3D viewer in the top right corner, and set its width to a third of the remaining space
+        // (after the controls width is taken into account)
+        int width3DViewer = (int) Math.floor((screenSize.getWidth() - frame.getWidth())/3.0);
+        universe.setSize(width3DViewer, viewHeight);
+        universe.getWindow().setLocation((int) Math.floor(screenSize.getWidth() - width3DViewer),
+                frame.getLocationOnScreen().y);
+
+        // Fill any remaining width between the controls and 3D viewer with the bdv window
         viewFrame.setLocation(
                 frame.getLocationOnScreen().x + frame.getWidth(),
                 frame.getLocationOnScreen().y );
-
-        universe.getWindow().setLocation(viewFrame.getLocationOnScreen().x + viewFrame.getWidth(),
-                viewFrame.getLocation().y);
+        int newViewWidth = (int) Math.floor(screenSize.width - width3DViewer - frame.getWidth());
+        viewFrame.setSize(newViewWidth, viewHeight);
     }
 
     public static void resetCrossPlatformSwingLookAndFeel() {


### PR DESCRIPTION
For https://github.com/automated-ultramicrotomy/crosshair/issues/35

- Places 3D viewer in top right corner (taking up 1/3 of remaining space after the controls are displayed)
- Bdv window takes up any remaining space between the controls and the 3D viewer