### PR TITLE
BigDataViewer deprecation warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,10 +101,6 @@
 		</dependency>
 		<dependency>
 			<groupId>sc.fiji</groupId>
-			<artifactId>bigdataviewer-vistools</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>sc.fiji</groupId>
 			<artifactId>bigdataviewer_fiji</artifactId>
 		</dependency>
 		<dependency>

--- a/src/main/java/de/embl/schwab/crosshair/bdv/BdvBehaviours.java
+++ b/src/main/java/de/embl/schwab/crosshair/bdv/BdvBehaviours.java
@@ -79,7 +79,7 @@ public class BdvBehaviours {
 
     private void addPlaneTrackingListener() {
         // When tracking a plane, changing the orientation of the BDV window should update the plane orientation
-        bdvHandle.getViewerPanel().addTransformListener(new bdv.viewer.TransformListener<AffineTransform3D>() {
+        bdvHandle.getViewerPanel().transformListeners().add(new bdv.viewer.TransformListener<AffineTransform3D>() {
             @Override
             public void transformChanged(AffineTransform3D affineTransform3D) {
                 if ( planeManager.isTrackingPlane() ) {

--- a/src/main/java/de/embl/schwab/crosshair/targetingaccuracy/AccuracyBdvBehaviours.java
+++ b/src/main/java/de/embl/schwab/crosshair/targetingaccuracy/AccuracyBdvBehaviours.java
@@ -77,7 +77,7 @@ public class AccuracyBdvBehaviours {
         final Behaviours behaviours = new Behaviours(new InputTriggerConfig());
         behaviours.install( bdvHandle.getTriggerbindings(), "accuracy" );
 
-        bdvHandle.getViewerPanel().addTransformListener(new bdv.viewer.TransformListener<AffineTransform3D>() {
+        bdvHandle.getViewerPanel().transformListeners().add( new bdv.viewer.TransformListener<AffineTransform3D>() {
             @Override
             public void transformChanged(AffineTransform3D affineTransform3D) {
                 if ( planeManager.isTrackingPlane() ) {


### PR DESCRIPTION
Remove deprecated bigdataviewer functions + bigdataviewer-vistools dependency (this has been merged with bigdataviewer-core)